### PR TITLE
Use functools from standard library on Python 3.7+ instead of singledispatch

### DIFF
--- a/jaraco/path.py
+++ b/jaraco/path.py
@@ -4,6 +4,7 @@ Tools for working with files and file systems
 
 import os
 import re
+import sys
 import itertools
 import functools
 import calendar
@@ -18,7 +19,10 @@ import importlib
 import pathlib
 from typing import Dict, Union
 
-from singledispatch import singledispatch
+if sys.version_info >= (3, 7):
+    from functools import singledispatch
+else:
+    from singledispatch import singledispatch
 
 
 log = logging.getLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 install_requires =
 	pyobjc; platform_system == "Darwin" and platform_python_implementation != "PyPy"
 	# until Python 3.6 is dropped
-	singledispatch >= 3.6
+	singledispatch >= 3.6;python_version<"3.7"
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]


### PR DESCRIPTION
Hello, 

I was trying to package `jaraco.path` into Fedora but the latest version of `singledispatch` there is just 3.4.0.3. Instead of backporting and updating `singledispatch` we would prefer not to use it at all and use `functools` from the standard library with Python 3.7 and higher.

Thanks!