### PR TITLE
Fix FilesSpec parameters variance issues by making it a Mapping instead of a dict

### DIFF
--- a/jaraco/path.py
+++ b/jaraco/path.py
@@ -16,8 +16,7 @@ import platform
 import ctypes
 import importlib
 import pathlib
-from typing import Dict, Protocol, Union
-from typing import runtime_checkable
+from typing import Mapping, Protocol, Union, runtime_checkable
 
 
 log = logging.getLogger(__name__)
@@ -285,7 +284,7 @@ class Symlink(str):
     """
 
 
-FilesSpec = Dict[str, Union[str, bytes, Symlink, 'FilesSpec']]
+FilesSpec = Mapping[str, Union[str, bytes, Symlink, 'FilesSpec']]
 
 
 @runtime_checkable

--- a/newsfragments/3.bugfix.rst
+++ b/newsfragments/3.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``FilesSpec`` parameters variance issues by making it a `typing.Mapping` instead of a `dict` -- by :user:`Avasam`


### PR DESCRIPTION
This fixes over around 30 `reportArgumentType` type errors right now in setuptools as found by pyright in https://github.com/pypa/setuptools/pull/4192
Around 80 as more dicts are typed more precisely than `dict[str, Any/Unknown]`

These would all eventually become type issues in mypy as well once that code is checked for.

Relates to https://github.com/jaraco/jaraco.path/issues/2